### PR TITLE
feat(foundation): EOS-3 in development + EOS-4 in planning + column rename 04_executing → 04_in_development

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ The `eos/` subtree under foundation is the governance heart of the entire olympu
 | Query | Source |
 |---|---|
 | **WHAT DOES OLYMPUS DO?** | `eos/cycle/06_shipped/` — every file is one immutable shipped+verified cycle. Together they ARE the system's specification. |
-| **WHAT IS OLYMPUS WORKING ON?** | `eos/cycle/05_verifying/` (telemetry assertions being validated) + `eos/cycle/04_executing/` (in flight). |
+| **WHAT IS OLYMPUS WORKING ON?** | `eos/cycle/05_verifying/` (telemetry assertions being validated) + `eos/cycle/04_in_development/` (in flight; formerly `04_executing/`). |
 | **WHAT IS THE ROADMAP?** | `eos/cycle/00_backlog` → `01_planning` → `02_design` → `03_ready`. Aborted work in `07_aborted/`. |
 
 **Canonical operating manual:** [`eos/cycle/README.md`](eos/cycle/README.md). Read this first when touching anything EOS. Scaffold for new cycles: [`eos/cycle/TEMPLATE.md`](eos/cycle/TEMPLATE.md).

--- a/eos/cycle/01_planning/brain_1.7.eos-4.md
+++ b/eos/cycle/01_planning/brain_1.7.eos-4.md
@@ -1,0 +1,100 @@
+# How does EOS-3 safely arrive in production
+
+> File: `brain_1.7.eos-4.md`
+
+| | |
+|---|---|
+| **Branch family** | `brain/1.7.x.x` |
+| **Cycle ordinal** | `eos-4` (4th on this branch family) |
+| **Status** | `Planning` — Steward authoring §1-§5. Cycle does NOT enter `04_in_development/` until EOS-3 reaches `06_shipped/` (single-open-cycle global mutex). |
+| **Opened** | 2026-06-09 |
+| **Closed** | — |
+| **Prior cycle** | `brain_1.7.eos-3` (the void → omens iPhone reproducibility cycle) |
+| **Theme** | The productionization of the EOS-3 path — how does the void→omens-iPhone slice safely become a production capability anyone can lean on |
+| **Feedback inputs** | TBD — populated from EOS-3 §13 closeout + §1.1-deviation bug accumulator |
+| **Estimated effort** | TBD |
+| **Actual effort** | — |
+
+> **What EOS-4 is (the productionization half of the EOS-1→4 culmination):**
+>
+> EOS-3 proves the path exists in development: void → scratch org → spawned Pantheon cluster → omens on iPhone running against it. **EOS-4 carries that same path safely into production.**
+>
+> The full culmination across EOS-1 + EOS-2 + EOS-3 + EOS-4 is:
+>
+> - the olympus-grid node
+> - the spawned olympus pantheon
+> - the gpt language to access it
+> - the omens game to utilize it
+> - the iris portal to support it
+> - the turtleshell-web and turtleshell-ios to demonstrate it
+>
+> **— fully backed, A to Z, for a sovereign AI system to run with or without the Steward. Requires Salesforce for now.**
+>
+> EOS-4 is what makes "with or without the Steward" actually true — the production-grade promotion path, recovery posture, and operational discipline that mean a dust dancer can stand up their own grid and trust it.
+
+---
+
+# § Steward-authored (top half)
+
+## §1 User story
+
+*Steward authors after EOS-3 closes and EOS-3's §13 surfaces what "production" actually means for each layer of the void→omens-iPhone path.*
+
+> Anticipated shape:
+> As **the Steward — and any dust dancer who chooses to run their own grid** I want **the EOS-3 path (void → spawned cluster → omens on iPhone) promoted from a development capability to a production capability** so that **anyone holding the source can stand up a sovereign grid that they trust will keep running with or without the Steward's intervention**.
+
+## §2 Acceptance criteria
+
+*PENDING — Steward to draft after EOS-3 §13 closeout. Likely shapes:*
+
+- Promotion path for the olympus-grid node from scratch org → production org (managed package install, sandbox→prod, alpha→beta→release).
+- Promotion path for the AWS Pantheon cluster (dev cluster spawn → production cluster spawn, including SSM secret distribution, CDN posture, alarm wiring).
+- omens iPhone artifact: TestFlight → App Store distribution.
+- Recovery / continuity posture: what happens when the Steward is unavailable.
+
+## §3 Non-functional requirements
+
+*PENDING.*
+
+## §4 Feedback inputs
+
+*PENDING — populated from EOS-3 §13 closeout. Will include the §1.1-deviation bug rows EOS-3 accumulated but deferred, prioritized for production safety.*
+
+## §5 Steward approval gate
+
+- [ ] Story locked (§1)
+- [ ] Criteria locked (§2)
+- [ ] NFRs locked (§3)
+- [ ] Approved to execute — signed: **{Steward initials}** **{date}**
+
+> *Single-open-cycle global mutex:* EOS-4 cannot enter `04_in_development/` until EOS-3 reaches `06_shipped/`. Until then this doc lives in `01_planning/` and the Steward iterates §1-§5 in place.
+
+---
+
+# § Agent-authored (bottom half)
+
+*§6-§13 PENDING. Decomposition begins after §5 sign-off AND EOS-3 closure.*
+
+## §6 Layer impact map
+*PENDING.*
+
+## §7 Schema deltas
+*PENDING.*
+
+## §8 Service contracts
+*PENDING.*
+
+## §9 Telemetry assertions
+*PENDING.*
+
+## §10 Execution plan
+*PENDING.*
+
+## §11 Verification protocol
+*PENDING.*
+
+## §12 Rollback plan
+*PENDING.*
+
+## §13 Closeout
+*PENDING.*

--- a/eos/cycle/04_in_development/brain_1.7.eos-3.md
+++ b/eos/cycle/04_in_development/brain_1.7.eos-3.md
@@ -1,0 +1,198 @@
+# Void → omens manifestation — the platform reproducible from nothing, zero errors, zero warnings, forever
+
+> File: `brain_1.7.eos-3.md`
+
+| | |
+|---|---|
+| **Branch family** | `brain/1.7.x.x` |
+| **Cycle ordinal** | `eos-3` (3rd on this branch family) |
+| **Status** | `In Development` — direct-to-execution under single-Steward mode; agent already in flight on a fresh scratch org; staged kanban (01→02→03) deferred until republic-616 lights up the multi-party §5 vote |
+| **Opened** | 2026-06-09 |
+| **Closed** | — |
+| **Prior cycle** | `brain_1.7.eos-2` (the Olympus-Grid command-plane truth loop — *"says what it does, does what it says: claim 1: athena-717 reachability"*) |
+| **Theme** | Void → omens manifestation — the platform reproducible from nothing, zero errors, zero warnings, forever |
+| **Feedback inputs** | EOS-2 §13.4 deferred gaps (G6.2 / G6.3 / G7 / G8 / G9 / G10) + EOS-2 §13.5 architectural seed (per-cluster `BrainVersion__c`) considered out-of-scope unless Steward widens |
+| **Estimated effort** | TBD — locked when §10 is authored. Plausibly the largest cycle to date because the assertion is platform-wide. |
+| **Actual effort** | — |
+
+> **What EOS-3 is (continues the methodology threads, narrows the claim for execution):**
+>
+> EOS-1 proved a **surface-telemetry continual-improvement loop** — a human plays the game, the platform receives the telemetry, the next cycle is informed by it. That loop stays on, untouched, forever.
+>
+> EOS-2 proved the **cluster-creator dynamic-access claim** — a Salesforce admin spawns an AWS cluster from inside the managed package and talks to it end-to-end with zero out-of-band touch.
+>
+> **EOS-3 closes the from-nothing-to-iPhone-running-omens claim.** Stand up a brand-new olympus-grid node from scratch (today a Salesforce scratch org; requires Salesforce for now). Spawn an AWS cluster against it. Run **omens on an iPhone** against that cluster end-to-end. When EOS-3 closes, **anyone holding the source can repeat this cycle.**
+>
+> EOS-3 does **not** require the §1.1 zero-error / zero-warning gold standard on each component and process. Bugs against §1.1 are tracked and prioritized across future cycles, not gating EOS-3 closure. The §1.1 ideal is the **forever intent** of the platform; EOS-3 is one concrete slice that proves the path exists.
+>
+> **The EOS-1 → EOS-2 → EOS-3 → EOS-4 culmination** is: the olympus-grid node, the spawned olympus pantheon, the gpt language to access it, the omens game to utilize it, the iris portal to support it, the turtleshell-web and turtleshell-ios to demonstrate it — **fully backed, A to Z, for a sovereign AI system to run with or without the Steward**. EOS-4 (already scaffolded in `01_planning/`) carries the productionization half of that culmination: *how does EOS-3 safely arrive in production*.
+
+---
+
+# § Steward-authored (top half)
+
+## §1 User story
+
+### §1.1 The reproducible platform from the void (the FOREVER intent)
+
+> As **the Steward — and eventually any dust dancer** I want **to stand up a brand-new olympus-grid node from scratch (today a Salesforce scratch org; tomorrow any host that can run `./build.sh`), watch it come to life, spawn AWS clusters against it, and have every client surface (omens, turtleshell-web, turtleshell-ios, iris portal, olympus-gpt) connect and run a real karmic cycle against it — with zero errors and zero warnings across the whole void→manifestation chain** so that **the platform proves it can be re-created from nothing, forever, by anyone holding the source, as a single reproducible command — and every surface inherits the EOS-1 continual-improvement telemetry loop and the EOS-2 cluster-creator dynamic-discovery contract by construction.**
+
+**§1.1 is intent. Short of §1.1 is a bug.** If there is an error, if there is a warning, it is a bug — we will fix it, we will get to it, prioritization is across cycles. EOS-3 is one slice of §1.1's path; future cycles continue along it.
+
+### §1.2 The EOS-3 slice (what we actually ship this cycle)
+
+> As **the Steward** I want **to go from nothing → a live olympus-grid scratch org → a spawned AWS Pantheon cluster → omens running on an iPhone connected to that cluster end-to-end** so that **anyone holding the source can repeat this cycle**.
+
+EOS-3 explicitly carves out turtleshell-web, turtleshell-ios (broadly), iris portal as a surface goal, and olympus-gpt — those are §1.1 surfaces and ride future cycles. **EOS-3 ships when the omens iPhone surface is alive on a freshly-provisioned cluster.**
+
+> *Constraint:* the node form is Salesforce scratch org for now. Widening the node form to any-host is a future EOS — out of scope here.
+
+## §2 Acceptance criteria
+
+*Draft sketches matching the EOS-3 slice (§1.2). Each criterion includes the observable post-condition in the session log or Salesforce data. Steward refines; agent decomposes into §6 once locked.*
+
+- **§2.1 Node from void.** **Given** a developer machine with the olympus-grid source checked out and no scratch org allocated **when** the Steward runs `./build.sh` from `olympus-grid/` root **then** within the §3 wall-clock budget a live olympus-grid scratch org exists, every canonical app (`Plugin.app_iris`, `Plugin.app_guardians`, `Plugin.app_olympus_gpt`, `Plugin.app_turtleshell`) is installed, the build exits with code 0, AND the session log carries `void.manifested.olympus_grid_node` with the new org's 18-char Id.
+
+- **§2.2 Cluster from node.** **Given** a live node from §2.1 **when** the Steward spawns an AWS Pantheon cluster from inside the managed package (the EOS-2 mechanism) **then** a `Cluster__c` row exists with `Status__c='Live'`, the Pantheon image pulls cleanly, every health endpoint returns 200, AND the session log carries `cluster.manifested.ec2_pantheon` with the cluster's `ClusterName__c`.
+
+- **§2.3 omens on iPhone against cluster.** **Given** a live cluster from §2.2 **when** the Steward opens omens on iPhone (deployed via `omens/tools/ios-deploy.sh`) targeted at that cluster's URL **then** the cosmos-logos handshake succeeds, MCP connects through Ares → Hermes → Athena, the player completes one karmic cycle (intent → state mutation → `LedgerEntry__c` → outcome), telemetry lands in `Feedback__c`, AND the EOS-1 surface-telemetry continual-improvement loop is active (`Feedback__c` row present with session-log attached).
+
+- **§2.4 Repeatability.** **Given** EOS-3 is closed **when** any human holding the source repeats §2.1 → §2.3 on a fresh machine **then** the chain completes without Steward intervention. This is the *"anyone can repeat this cycle"* closure condition from §1.2.
+
+> **Out of scope for EOS-3** (rides future cycles, NOT criteria here): turtleshell-web surface, turtleshell-ios surface (broadly — note iPhone is in scope ONLY as the omens runtime, not as the turtleshell-ios app), iris portal as a surface goal (iris's admin UI is the §2.2 mechanism, not the §2.3 surface claim), olympus-gpt surface, the §1.1 zero-error / zero-warning gold standard.
+>
+> **§1.1 deviations encountered during EOS-3 execution become bug entries**, logged inline in §13 and triaged into future cycles by priority. They do NOT gate this cycle.
+
+## §3 Non-functional requirements
+
+*Categories pre-stubbed for Steward to fill. Pre-stub note: every EOS-3 budget is a baseline; the cycle's value is partly that those budgets become baselines for future regression checks.*
+
+- **Cycle latency budget** — wall-clock budget for `./build.sh` to "live node" (§2.1). Wall-clock budget for cluster spawn (§2.2). End-to-end wall-clock budget for void → first karmic cycle complete (§2.1 → §2.3).
+- **Cost budget** — AWS spend per cluster spawn (relevant for dev iteration cadence). Scratch org allocation count per Steward / per dust dancer.
+- **Observability** — every void → manifest action emits a `CycleId`-tagged log line traceable from client → server → Plutus ledger. `Cycle__c` row exists for the meta-cycle (the EOS-3 manifestation cycle itself) referenced by every nested action.
+- **Compatibility** — cluster naming convention from EOS-2 (`api-int`, `api-prod`, etc.) preserved. cosmos-logos handshake protocol unchanged. Existing shipped surfaces (`brain/1.7.x.x` HEAD) remain functional during transition.
+- **Privacy** — no PII in build logs. No secret material (private keys, OAuth tokens) ever logged.
+- **Performance** — frame budgets on omens unchanged. iris portal initial paint ≤ N seconds. cluster spawn does not exceed N parallel AWS API calls (rate-limit hygiene).
+
+## §4 Feedback inputs
+
+This cycle is forward-looking (not feedback-driven from a specific play cycle), but it directly closes the deferred gaps from EOS-2's closeout:
+
+| Source | Gap | Pattern |
+|--------|-----|---------|
+| EOS-2 §13.4 | **G6.2 / G6.3** — source-controlled cert files load-bearing for local dev boot | discover at boot, fail-loud on missing |
+| EOS-2 §13.4 | **G7** — olympus-gpt `apiBase` hardcoded | discover from spawning org |
+| EOS-2 §13.4 | **G8** — Ares CORS not sovereign-org-aware | discover allowed origins from cluster row |
+| EOS-2 §13.4 | **G9** — omens client `AuthUrl` hardcoded (spec at `docs/handoff-omens-dynamic-cluster-discovery.md`) | discover from spawning org |
+| EOS-2 §13.4 | **G10** — hermes `unmanaged` fix uncommitted | permanent hermes PR |
+| EOS-2 §13.5 | **`Cluster__c.BrainVersion__c`** — per-cluster brain version pinning for mixed-version customer fleets | candidate; Steward decides if EOS-3 or EOS-4 |
+
+The unifying primitive across all five EOS-2-deferred gaps: **discover state from the spawning org, cache at the consumer, fail-loud on missing.** EOS-3's §6 decomposition operationalizes that primitive as a platform-wide invariant.
+
+## §5 Steward approval gate
+
+- [ ] Story locked (§1)
+- [ ] Criteria locked (§2)
+- [ ] NFRs locked (§3)
+- [ ] Approved to execute — signed: **{Steward initials}** **{date}**
+
+> *Single-Steward mode.* Until republic-616 ships, §5 is a single Steward sign-off and the cycle proceeds directly within `04_in_development/`. When the multi-party vote lands, this checkbox becomes a vote record and the doc walks through `03_ready/` before entering `04_in_development/`.
+
+---
+
+# § Agent-authored (bottom half)
+
+> **State of §6-§12 as of 2026-06-09:** *PENDING.* An agent is already in flight against a fresh scratch org doing the actual platform work that §10 will codify. The EOS agent will sync with that in-flight work and author §6-§12 inline once the §5 gate is ticked. The doc itself becomes the coordination layer between the EOS agent and the in-flight scratch-org agent.
+
+## §6 Layer impact map
+
+*PENDING. To be authored after §5 sign-off, in sync with the in-flight scratch-org agent.*
+
+| Criterion | Salesforce (olympus-grid) | Pantheon services | omens (Godot) | turtleshell-web | iris portal | SDK / protocol |
+|-----------|---------------------------|-------------------|---------------|-----------------|-------------|----------------|
+| §2.1 | … | … | … | … | … | … |
+| §2.2 | … | … | … | … | … | … |
+| §2.3 | … | … | … | … | … | … |
+| §2.4 | … | … | … | … | … | … |
+| §2.5 | … | … | … | … | … | … |
+| §2.6 | aggregator | aggregator | aggregator | aggregator | aggregator | aggregator |
+
+## §7 Schema deltas
+
+*PENDING. Anticipated candidates pulled from EOS-2 §13 forward-looking notes:*
+
+- Possible new field `Cluster__c.BrainVersion__c` (per-cluster brain version pinning) — Steward to confirm whether in EOS-3 scope.
+- Possible new `Node__c` SObject if "node" becomes a first-class entity distinct from a Salesforce org (e.g., when the node form expands beyond scratch orgs).
+- `Cycle__c` row for the EOS-3 meta-cycle so the manifestation chain is traceable end-to-end.
+
+## §8 Service contracts
+
+*PENDING.* Anticipated touchpoints: every consumer's discovery handshake (omens, olympus-gpt, ares CORS, hermes managed-mode, local-dev cert lookup) replaces a hardcoded URL/cert with a fetch-from-spawning-org call. Wire shape to be drafted once the in-flight agent's pattern is read.
+
+## §9 Telemetry assertions (the close-out gate)
+
+*Draft assertions matching the EOS-3 slice (§1.2 / §2.1-§2.4) — refine after §6/§7/§8 are authored:*
+
+- `void.manifested.olympus_grid_node` must fire once per `./build.sh` invocation against an empty starting state; payload carries new-org Id + wall-clock duration.
+- `cluster.manifested.ec2_pantheon` must fire once per cluster spawn; payload carries `ClusterName__c` + duration.
+- `surface.connected.omens_ios` must fire once when omens on iPhone successfully completes its cosmos-logos handshake against a freshly-spawned cluster.
+- Every HTTP envelope across the void→manifest chain carries `cycleId` matching the EOS-3 meta-cycle row.
+- Plutus ledger SOQL `SELECT * FROM LedgerEntry__c WHERE Cycle__c = :eos3_cycle_id` returns ≥ N rows for the N actions executed during verification.
+
+> **NOT a gate** (§1.1 forever-intent, not EOS-3 closure): zero occurrences of severity `error|fatal|warn` across the chain. Any deviations encountered during verification become bug rows in §13 and seed future cycles.
+
+## §10 Execution plan
+
+*PENDING.* The in-flight scratch-org agent is already executing what §10 will record. The EOS agent will read that work, decompose it into ordered tasks with cross-layer dependencies, and inline it here. Until then, this section is the working contract between the EOS agent and the in-flight agent.
+
+## §11 Verification protocol
+
+*PENDING.* Anticipated:
+
+### Without iPhone
+- `./build.sh` from a clean clone → confirm §2.1
+- iris admin UI flow → confirm §2.2
+- turtleshell-web in Chromium → confirm §2.4
+- iris portal in Chromium → confirm §2.5
+- omens Godot desktop → partial §2.3
+
+### With iPhone (required for §2.3 if turtleshell-ios is in scope)
+- `omens/tools/ios-deploy.sh` → omens iPhone targeted at the new cluster
+
+## §12 Rollback plan
+
+*PENDING.* The cycle is platform-wide, so rollback is mostly per-layer: scratch org deletion is cheap, AWS cluster destroy via `zeus-destroy.yml` is documented, omens client revert is `git revert` clean. The risk surface is in the discover-from-spawning-org refactors — those will need per-PR rollback notes captured in §10 as tasks are decomposed.
+
+## §13 Closeout
+
+*Filled at end of cycle. Doc goes immutable after this.*
+
+### What shipped
+- …
+
+### What deferred (and why)
+- …
+
+### What surprised
+- …
+
+### Verification evidence
+- …
+
+### §1.1 deviations observed during EOS-3 (the bug accumulator)
+
+> Every error / warning surfaced during EOS-3 verification gets logged here as a §1.1-deviation bug row. Each row points to a future-cycle slot for triage. EOS-3 does NOT gate on this list — it gates on §2.1-§2.4 / §9.
+
+| Bug | Where surfaced | Severity | Triage target | Notes |
+|-----|----------------|----------|---------------|-------|
+| … | … | … | EOS-? | … |
+
+### Feedback that emerged from THIS cycle (seed for the next one)
+- …
+
+### Memory updates
+- …
+
+### Cycle close commit
+- …
+- Steward sign-off: **{Steward initials}** **{date}**

--- a/eos/cycle/README.md
+++ b/eos/cycle/README.md
@@ -75,7 +75,7 @@ foundation/eos/cycle/
 ├── 01_planning/                   ← Steward is authoring §1-§5 (story/criteria/NFRs)
 ├── 02_design/                     ← Agent is decomposing §6-§12 (Steward reviewing)
 ├── 03_ready/                      ← Steward approved §5 + Agent approved §6-§12; ready to execute
-├── 04_executing/                  ← in flight; §10 plan being worked through
+├── 04_in_development/             ← in flight; §10 plan being worked through (formerly `04_executing/`)
 ├── 05_verifying/                  ← code shipped; §9 telemetry assertions being validated
 ├── 06_shipped/                    ← closed out + immutable
 └── 07_aborted/                    ← Steward killed pre-shipment; rationale recorded in §13
@@ -129,7 +129,7 @@ chore(eos): move {filename} from {source-stage} to {target-stage}
    └────────────────────────────┬────────────────────────────────────┘
                                 ▼  git mv to 03_ready/ (both halves signed)
    ┌─────────────────────────────────────────────────────────────────┐
-   │  Agent claims doc → git mv 04_executing/, ships §10 plan        │
+   │  Agent claims doc → git mv 04_in_development/, ships §10 plan  │
    └────────────────────────────┬────────────────────────────────────┘
                                 ▼  git mv to 05_verifying/
    ┌─────────────────────────────────────────────────────────────────┐
@@ -169,7 +169,18 @@ By a small-N EOS cycle, we'll have a Lightning Web Component for batch-promoting
 ## Inventory
 
 - [`TEMPLATE.md`](TEMPLATE.md) — empty scaffold; copy when starting a new cycle.
-- [`01_planning/brain_1.7.eos-1.md`](01_planning/brain_1.7.eos-1.md) — **OPEN** · the first EOS cycle on `brain/1.7.x.x` · **system is not go-live ready until this ships**.
+- [`06_shipped/brain_1.7.eos-1.md`](06_shipped/brain_1.7.eos-1.md) — **SHIPPED** (2026-05-31) · portal lifecycle + cycle tracking infrastructure · the consumer feedback loop on turtleshell + guardians; the baseline of stable application across all repos.
+- [`06_shipped/brain_1.7.eos-2.md`](06_shipped/brain_1.7.eos-2.md) — **SHIPPED** (parent PR #166) · *Says what it does, does what it says — claim 1: athena-717 reachability* · Salesforce admin spawns an AWS cluster and talks to it end-to-end from inside the managed package, zero out-of-band touch.
+- [`04_in_development/brain_1.7.eos-3.md`](04_in_development/brain_1.7.eos-3.md) — **IN DEVELOPMENT** · *Void → omens manifestation* · §1.1 forever-intent is the platform reproducible from nothing with zero errors / zero warnings; **the EOS-3 slice that actually ships is the narrower path: void → spawned cluster → omens on iPhone running against it, repeatable by anyone holding the source**. §1.1 deviations encountered during EOS-3 are logged as bug rows and triaged into future cycles, not gating closure.
+- [`01_planning/brain_1.7.eos-4.md`](01_planning/brain_1.7.eos-4.md) — **PLANNING** · *How does EOS-3 safely arrive in production* · the productionization half of the EOS-1→4 culmination. Cannot enter `04_in_development/` until EOS-3 reaches `06_shipped/` (single-open-cycle global mutex).
+
+## Note on the column rename and direct-to-execution path (single-Steward mode)
+
+Through EOS-2, the in-flight column was named `04_executing/`. From EOS-3 forward, it is **`04_in_development/`** — the name better matches how the work actually feels (live development across every repo) rather than just "executing a pre-decomposed plan."
+
+EOS-3 was also placed directly into `04_in_development/` without walking through `01_planning → 02_design → 03_ready`. The staged kanban is the **multi-party governance flow** that lights up when republic-616 ships and dust dancers vote on §5. Until then, under single-Steward mode, the Steward may place a cycle directly into `04_in_development/` after approving its theme — the §1-§5 + §6-§13 sections are still authored (the document is still the contract), but they evolve inside the in-development column rather than via inter-column promotions. When republic-616 lands, the kanban progression becomes mandatory again because the multi-party §5 vote requires a discrete "ready for vote" state.
+
+**Single-open-cycle global mutex — relaxation under single-Steward mode.** The canonical rule is that at most one cycle may occupy stages `01_planning` through `05_verifying` at any time across the universe. Under single-Steward mode the Steward may also **scaffold the next cycle's planning doc in `01_planning/` while the current cycle is in `04_in_development/`** — the Steward holds the cross-cycle coherence constraint themselves rather than relying on the folder tree as a structural mutex. The next cycle still cannot enter `04_in_development/` until the prior reaches `06_shipped/`. When republic-616 lands, the strict mutex re-engages: `01_planning/` empty whenever `04_in_development/` is occupied, because a multi-party body cannot reliably hold the coherence constraint mentally the way a single Steward can. (Patent claim 6 covers the strict mutex; the relaxation here is a single-author-mode optimization, not a removal of the claim.)
 
 ## Reference
 


### PR DESCRIPTION
## Summary

Opens **EOS-3** ("Void → omens manifestation — the platform reproducible from nothing, zero errors, zero warnings, forever") in `04_in_development/`, scaffolds **EOS-4** ("How does EOS-3 safely arrive in production") in `01_planning/`, and renames the in-flight kanban column from `04_executing/` to `04_in_development/` to better match the "live development across every repo" feel of the work.

EOS-3 §1.1 is the **forever intent** of the platform — the platform reproducible from nothing, zero errors, zero warnings, forever. §1.2 narrows EOS-3's actual ship slice to: **void → live olympus-grid scratch org → spawned AWS Pantheon cluster → omens running on iPhone against that cluster, repeatable by anyone holding the source**. §1.1 deviations encountered during EOS-3 are logged inline as bug rows in §13 and triaged into future cycles — they do NOT gate EOS-3 closure.

EOS-4 is the productionization half of the EOS-1→4 culmination: *the olympus-grid node + spawned olympus pantheon + the gpt language to access it + the omens game to utilize it + the iris portal to support it + turtleshell-web and turtleshell-ios to demonstrate it — fully backed, A to Z, for a sovereign AI system to run with or without the Steward. Requires Salesforce for now.*

## Changes

- **`CLAUDE.md`** — updated WHAT-IS-OLYMPUS-WORKING-ON row in the three-queries table: column rename `04_executing/` → `04_in_development/`.
- **`eos/cycle/README.md`**:
  - Folder structure ASCII (line 78): column rename.
  - Lifecycle diagram (line 132): column rename.
  - Inventory section: dropped stale eos-1-as-OPEN entry; added EOS-1 + EOS-2 as SHIPPED with theme + closure dates; added EOS-3 IN DEVELOPMENT with the §1.1-vs-§1.2 framing; added EOS-4 PLANNING.
  - New section **"Note on the column rename and direct-to-execution path (single-Steward mode)"** documenting why the column was renamed AND why single-Steward mode permits direct-to-execution placement. Also documents the **single-open-cycle global mutex relaxation** under single-Steward mode (EOS-3 in `04_in_development/` + EOS-4 in `01_planning/` simultaneously) — calling out that the strict mutex (patent claim 6) re-engages when republic-616 lights up multi-party §5 voting.
- **`eos/cycle/04_in_development/brain_1.7.eos-3.md`** — new cycle doc:
  - Metadata header: `In Development`, prior cycle `brain_1.7.eos-2`, theme "void → omens manifestation", feedback inputs = EOS-2 §13.4 deferred gaps + §13.5 BrainVersion__c forward seed.
  - §1.1 — forever intent (the platform reproducible from nothing, zero errors / zero warnings).
  - §1.2 — the EOS-3 slice (void → cluster → omens iPhone, repeatable by anyone). Out-of-scope explicitly: turtleshell-web, turtleshell-ios broadly, iris-as-surface, olympus-gpt, the zero-error gold standard.
  - §2.1-§2.4 — Gherkin acceptance criteria matching §1.2 (node from void, cluster from node, omens on iPhone against cluster, repeatability).
  - §3 NFR categories stubbed.
  - §4 feedback inputs (EOS-2 §13.4 / §13.5).
  - §5 gate unticked, with a single-Steward-mode note.
  - §6-§12 marked PENDING — to be authored by the EOS agent in sync with the in-flight scratch-org-validation work.
  - §9 draft assertions matching §1.2 scope (NOT gating on zero-error / zero-warning).
  - §13 stubbed with a new **§1.1-deviation bug accumulator table** so errors / warnings observed during EOS-3 verification are captured for future-cycle triage instead of gating EOS-3.
- **`eos/cycle/01_planning/brain_1.7.eos-4.md`** — new planning doc:
  - Theme: *"how does EOS-3 safely arrive in production"*.
  - Carries the EOS-1→4 culmination framing in the header.
  - §1-§13 PENDING — Steward authors §1-§5 after EOS-3 §13 closeout informs what "production" actually means for each layer.
  - Single-open-cycle mutex noted in §5: EOS-4 cannot enter `04_in_development/` until EOS-3 reaches `06_shipped/`.

## Canon-level flags

1. **Single-open-cycle global mutex relaxation.** Holding EOS-3 in `04_in_development/` + EOS-4 in `01_planning/` simultaneously is a **single-Steward-mode relaxation** of patent claim 6. The strict mutex re-engages once republic-616 lights up multi-party §5 voting. Surfaced explicitly in README so the relaxation is documented, not silently rewriting canon.
2. **Direct-to-execution path.** EOS-3 was placed directly into `04_in_development/` without walking through `01_planning → 02_design → 03_ready`. The staged kanban remains the canonical multi-party flow; single-Steward mode bypasses it. Documented inline in README.
3. **06_shipped/ immutability respected.** The 4 `04_executing/` references inside `brain_1.7.eos-1.md` were NOT touched — canon history is immutable.

## Test plan

- [x] Diff inspected: 4 files, +313 / -4. All additive or rename-only; no canon history mutated.
- [x] Folder structure: `04_in_development/` created with EOS-3 doc; `01_planning/` populated with EOS-4 doc.
- [x] Grep for stale `04_executing/` references outside `06_shipped/`: zero hits.
- [ ] Steward read of EOS-3 §1.1 + §1.2 + §2.1-§2.4 + §13 bug accumulator — refinements applied as subsequent commits to this branch.
- [ ] Steward sign-off on §5 once §1-§3 lock.
- [ ] EOS agent authors §6-§12 in sync with in-flight scratch-org validation work (Steward confirming the existing scratch org design will carry EOS-3, then promoting to production org in preparation for EOS-4).

## Risk / Rollback

Docs-only. No executable surface. Revert by reverting this PR's single commit. The column rename is the only mildly invasive change — if reversed, `git mv 04_in_development/ 04_executing/` restores the prior name without touching content.

## Linked

- Builds on PR #31 (the EOS-agent contract in `foundation/CLAUDE.md`).
- Carries forward the deferred gaps from EOS-2 §13.4 (G6.2 / G6.3 / G7 / G8 / G9 / G10) under the unifying primitive "discover state from the spawning org, cache at the consumer, fail-loud on missing."
- Carries forward the EOS-2 §13.5 forward seed (`Cluster__c.BrainVersion__c`) as a candidate; Steward decides if in EOS-3 scope or rides EOS-4 / later.